### PR TITLE
fix(tsconfig): make build and npm run commands work correctly

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
   "watch": ["dist"],
   "ext": "js",
-  "exec": "node dist/main"
+  "exec": "node -r ./tsconfig-bootstrap.js dist/src/main"
 }

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "build": "tsc -p tsconfig.build.json",
     "format": "prettier --write \"src/**/*.ts\"",
     "start": "ts-node -r tsconfig-paths/register src/main.ts",
-    "start:dev": "concurrently --handle-input \"wait-on dist/main.js && nodemon\" \"tsc -w -p tsconfig.build.json\" ",
+    "start:dev": "concurrently --handle-input \"wait-on dist/src/main.js && nodemon\" \"tsc -w -p tsconfig.build.json\" ",
     "start:debug": "nodemon --config nodemon-debug.json",
     "prestart:prod": "rimraf dist && npm run build",
-    "start:prod": "node dist/main.js",
+    "start:prod": "node -r ./tsconfig-bootstrap.js dist/main.js",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@nestjs/common": "^6.0.0",
     "@nestjs/core": "^6.0.0",
-    "@nestjs/platform-express": "^6.0.0", 
+    "@nestjs/platform-express": "^6.0.0",
     "reflect-metadata": "^0.1.12",
     "rimraf": "^2.6.2",
     "rxjs": "^6.3.3"
@@ -46,7 +46,11 @@
     "wait-on": "^3.2.0"
   },
   "jest": {
-    "moduleFileExtensions": ["js", "json", "ts"],
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
     "rootDir": "src",
     "testRegex": ".spec.ts$",
     "transform": {

--- a/tsconfig-bootstrap.js
+++ b/tsconfig-bootstrap.js
@@ -1,0 +1,8 @@
+const config = require('./tsconfig.json');
+const tsconfigPaths = require('tsconfig-paths');
+
+const baseUrl = './dist';
+tsconfigPaths.register({
+  baseUrl,
+  paths: config.compilerOptions.paths
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       ]
     }
   },
+  "include": ["src/**/*.ts", "libs/**/*.ts"],
   "exclude": [
-    "node_modules"
+    "node_modules", "dist/**"
   ]
 }


### PR DESCRIPTION
So, I have run into problems with paths many many many times. Always a headache, always a problem. I've never had luck with the command `node -r tsconfig-paths/register dist/main.js` or anything similar. Finally I found a solution using a bootstrap function that reads the paths from the tsconfig file and I've added it to the GitHub repo. 

Something that I noticed was happening, and the reason the build was not working as I was expecting it to, is that `tsc` will find all modules and files related to the project being built, and as you had paths set up, the`libs` folder was necessary to build, invalidating all the advice we gave you on setting two different build phases. SO right now, it still builds to `dist/src` and `dist/libs` but I do have the `start:dev` and `start:prod` commands working so long as you are okay with adding in an extra script (you can read through and verify it of course). If you want to get more in depth the the `tsc` compiler I would highly suggest reading through the [module resolution section on the typescript website ](https://www.typescriptlang.org/docs/handbook/module-resolution.html) . Path resolution, like I said, has always been an issue for me,  but I stand by the fact that in theory it would work with what Brunner and I have said about multiple build phases if the paths option was not there. Here is the script if you want to send it immediately:

```js
const config = require('./tsconfig.json');
const tsconfigPaths = require('tsconfig-paths');

const baseUrl = './dist';
tsconfigPaths.register({
  baseUrl,
  paths: config.compilerOptions.paths
});
```